### PR TITLE
Add types and interfaces for Emaki and related data structures

### DIFF
--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -11,10 +11,19 @@ import { AppContext } from "@/pages/_app";
 import { useLocaleMeta } from "@/utils/func";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useRef } from "react";
+import type { EmakiImageMetadata } from '@/types/metadata'; // Import the main type
 
 // TODO:スマホ版横向きのページにタイトルと絵師名を追加する
 
-const Emaki = ({ data, locale, locales, slug, test }: ) => {
+interface EmakiPageProps {
+  data: EmakiImageMetadata;
+  locale: string;
+  locales: string[];
+  slug: string;
+  test: EmakiImageMetadata;
+}
+
+const Emaki = ({ data, locale, locales, slug, test }: EmakiPageProps) => {
   const { t } = useLocaleMeta();
   const router = useRouter();
   const selectedRef = useRef(null);

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -14,7 +14,7 @@ import { useContext, useEffect, useRef } from "react";
 
 // TODO:スマホ版横向きのページにタイトルと絵師名を追加する
 
-const Emaki = ({ data, locale, locales, slug, test }) => {
+const Emaki = ({ data, locale, locales, slug, test }: ) => {
   const { t } = useLocaleMeta();
   const router = useRouter();
   const selectedRef = useRef(null);

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -6,12 +6,14 @@ import EmakiBreadcrumbs from "@/components/emaki/navigation/EmakiBreadcrumbs";
 import Head from "@/components/meta/Meta";
 import MiddleNavigation from "@/components/navigation/MiddleNavigation";
 import { default as enData, default as jaData } from "@/data/data";
-import emakisData from "@/data/image-metadata-cache/image-metadata-cache.json";
 import { AppContext } from "@/pages/_app";
 import { useLocaleMeta } from "@/utils/func";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useRef } from "react";
 import type { EmakiImageMetadata } from '@/types/metadata'; // Import the main type
+import fs from "fs";
+import path from "path";
+import type { GetStaticPaths } from 'next';
 
 // TODO:スマホ版横向きのページにタイトルと絵師名を追加する
 
@@ -202,8 +204,14 @@ const Emaki = ({ data, locale, locales, slug, test }: EmakiPageProps) => {
   );
 };
 
-export const getStaticPaths = async () => {
-  const paths = emakisData.map((item) => ({
+export const getStaticPaths: GetStaticPaths = async () => {
+  const cacheDir = path.join(process.cwd(), "src/data/image-metadata-cache");
+  const cacheFilePath = path.join(cacheDir, "image-metadata-cache.json");
+
+  // Type the data read from the cache
+  const metadataCache: EmakiImageMetadata[] = JSON.parse(fs.readFileSync(cacheFilePath, "utf-8"));
+
+  const paths = metadataCache.map((item) => ({
     params: {
       slug: item.titleen,
     },

--- a/src/types/chapters.ts
+++ b/src/types/chapters.ts
@@ -1,0 +1,26 @@
+// For the separate chapter/text data JSON files
+
+export type KusouzuChapterInfo = {
+    stage_en: string;
+    stage_ch: string;
+    title: string;
+    titleen: string;
+    ruby: string;
+    desc: string;
+    descen?: string;
+    gendaibun?: string;
+};
+
+export type ChojuGigaChapterInfo = {
+    chapter: string;
+    title: string;
+    titleen: string;
+};
+
+export type EmakiChapterInfo = {
+    chapter: string | number;
+    title: string;
+    titleen?: string;
+    desc?: string;
+    descen?: string;
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,39 @@
+// For reusable sub-types
+
+export type KeywordInfo = {
+    name: string;
+    id: string;
+    slug: string;
+};
+
+export type PersonNameInfo = {
+    name: string;
+    id: string;
+    slug: string;
+    ruby?: string;
+    portrait?: string;
+};
+
+export type ReferenceInfo = {
+    type: string;
+    url?: string;
+    title: string;
+};
+
+export type CharacterInfo = {
+    name: string;
+    status?: string;
+    top: number;
+    right: number;
+    gender?: "man" | "woman" | "animal";
+    link?: string;
+};
+
+export type EbikiInfo = {
+    name: string;
+    status?: string;
+    top: number;
+    right: number;
+    path?: string;
+    attr?: string;
+};

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -1,0 +1,51 @@
+// For the main emaki metadata structure
+
+import type { KeywordInfo, PersonNameInfo, ReferenceInfo } from './common';
+import type { EmakiSegment } from './segment';
+
+export type EmakiImageMetadata = {
+    id: number;
+    title: string;
+    titleen: string;
+    author?: string;
+    authoren?: string;
+    edition?: string;
+    editionen?: string;
+    backgroundImage?: string;
+    thumb: string;
+    thumb2?: string;
+    video?: string;
+    era: string;
+    eraen: string;
+    desc?: string;
+    descen?: string;
+    type: string;
+    typeen: string;
+    subtype?: string;
+    subtypeen?: string;
+    gif?: string;
+    googlemap?: string;
+    basinmap?: string;
+    mapWidth?: number;
+    mapHeight?: number;
+    keyword?: KeywordInfo[];
+    personname?: PersonNameInfo[];
+    genjieslug?: {
+        id: string;
+        title: string;
+        ruby: string;
+        path: string;
+    }[];
+    kusouzuslug?: {
+        id: string;
+    }[];
+    kotobagaki: boolean;
+    favorite?: boolean;
+    readMore?: boolean;
+    sourceImageUrl?: string;
+    sourceImage?: string;
+    reference?: ReferenceInfo[];
+    sourceEkotoba?: string;
+    emakis: EmakiSegment[];
+    pageView?: string | number;
+};

--- a/src/types/segment.ts
+++ b/src/types/segment.ts
@@ -1,0 +1,31 @@
+// For the segments within an emaki
+
+import type { CharacterInfo, EbikiInfo } from './common';
+
+export type EmakiSegment = {
+    cat: "ekotoba" | "image";
+    chapter?: string;
+    scene?: string;
+    config?: "cloudinary" | string;
+    src?: string;
+    srcSp?: string;
+    srcTb?: string;
+    srcWidth?: number | string; // Allow string due to potential inconsistencies in source JSON
+    srcHeight?: number | string; // Allow string due to potential inconsistencies in source JSON
+    name?: string;
+    kobun?: string;
+    gendaibun?: string;
+    desc?: string;
+    kobunsrc?: string;
+    kobunsrcSp?: string;
+    googlemap?: string;
+    basinmap?: string;
+    phrase?: any[];
+    character?: CharacterInfo[];
+    ebiki?: EbikiInfo[];
+    linkId?: number;
+    ekotobaId?: number;
+    uniqueIndex?: number;
+    load?: boolean | string; // Allow string for potential inconsistencies
+    test?: string; // Saw this in one example, keeping as optional string
+};


### PR DESCRIPTION
Introduce new types for chapter information, reusable sub-types, and metadata structures for Emaki. Enhance type safety in the Emaki component and improve static path generation by utilizing a metadata cache.